### PR TITLE
Allow for non-exclusive access to property wrapper

### DIFF
--- a/Bindable.xcodeproj/project.pbxproj
+++ b/Bindable.xcodeproj/project.pbxproj
@@ -64,6 +64,20 @@
 			remoteGlobalIDString = "Bindable::BindableTests";
 			remoteInfo = BindableTests;
 		};
+		E2D2855123D83BED00D6BF23 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Bindable::BindableNSObject";
+			remoteInfo = BindableNSObject;
+		};
+		E2D2855323D83BF900D6BF23 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Bindable::Bindable";
+			remoteInfo = Bindable;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -256,6 +270,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				E2D2855423D83BF900D6BF23 /* PBXTargetDependency */,
 			);
 			name = BindableNSObject;
 			productName = BindableNSObject;
@@ -272,6 +287,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				E2D2855223D83BED00D6BF23 /* PBXTargetDependency */,
 				OBJ_99 /* PBXTargetDependency */,
 			);
 			name = BindableTests;
@@ -405,6 +421,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		E2D2855223D83BED00D6BF23 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Bindable::BindableNSObject" /* BindableNSObject */;
+			targetProxy = E2D2855123D83BED00D6BF23 /* PBXContainerItemProxy */;
+		};
+		E2D2855423D83BF900D6BF23 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Bindable::Bindable" /* Bindable */;
+			targetProxy = E2D2855323D83BF900D6BF23 /* PBXContainerItemProxy */;
+		};
 		OBJ_77 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Bindable::BindableTests" /* BindableTests */;

--- a/Sources/Bindable/BindableProperty.swift
+++ b/Sources/Bindable/BindableProperty.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @propertyWrapper
-public struct Bindable<Value> {
+public class Bindable<Value> {
   private let source: VariableSource<Value>
 
   public let projectedValue: Variable<Value>

--- a/Tests/BindableTests/BindablePropertyTests.swift
+++ b/Tests/BindableTests/BindablePropertyTests.swift
@@ -32,4 +32,14 @@ class BindablePropertyTests: XCTestCase {
 
     XCTAssertEqual(model.$age.value, 1)
   }
+
+  func testExclusiveAccess() {
+    let model = MockModel(age: 0)
+    model.$age.subscribe { _ in
+      print(model.age)
+    }.disposed(by: disposeBag)
+    model.age = 1
+
+    XCTAssertEqual(model.$age.value, 1)
+  }
 }


### PR DESCRIPTION
Change from using a struct to a class, to allow for reading the property wrapper in the callback triggered by writing to it.

Example:

    let model = MockModel(age: 0)
    model.$age.subscribe { _ in
      print(model.age)
    }.disposed(by: disposeBag)
    model.age = 1

Details:
> Properties can be classified into three groups:
> - instance properties of value types
> - instance properties of reference types
> - static and class properties on any kind of type
> 
> Only modifications of the first kind of property (instance properties) require exclusivity access to entire storage of the aggregate value … The other two kinds of properties are enforced separately, as independent storage.

https://swift.org/blog/swift-5-exclusivity